### PR TITLE
Add support for older python versions

### DIFF
--- a/jedox_auto_dockerize.py
+++ b/jedox_auto_dockerize.py
@@ -57,7 +57,7 @@ class dockerizer(default_logger):
             description=p.get("description",p["target"])
 
             self.logger.info("patching : %s" % description)
-            subprocess.run("patch %s < %s" % (target,p["source"]),shell=True)
+            subprocess.check_call("patch %s < %s" % (target,p["source"]),shell=True)
 
     def add(self):
         self.logger.info("adding additional content to installation")
@@ -76,7 +76,7 @@ class dockerizer(default_logger):
     def build_base_image(self,image_name="jedox/base"):
         os.chdir(self.args["jedox_home"])
         self.logger.info("Import Jedox Suite into intermediate docker image '%s'" % image_name)
-        subprocess.call("""tar --to-stdout --numeric-owner --exclude=/proc --exclude=/sys --exclude='*.tar.gz' --exclude='*.log' -c ./ | docker import --change "CMD while true; do ping 8.8.8.8; done" --change "ENV TERM=xterm" - %s""" % image_name, shell=True)
+        subprocess.check_call("""tar --to-stdout --numeric-owner --exclude=/proc --exclude=/sys --exclude='*.tar.gz' --exclude='*.log' -c ./ | docker import --change "CMD while true; do ping 8.8.8.8; done" --change "ENV TERM=xterm" - %s""" % image_name, shell=True)
         self.logger.info("successfully create basecontainer %s" % image_name)
 
 

--- a/jedox_auto_installer.py
+++ b/jedox_auto_installer.py
@@ -131,11 +131,11 @@ class jedox_installer(default_logger):
             self.logger.info("install finished output below")
 
     def start(self):
-        subprocess.run(["/opt/jedox/ps/jedox-suite.sh","start"], shell=False, check=True)
+        subprocess.check_call(["/opt/jedox/ps/jedox-suite.sh","start"], shell=False)
         #Starting httpd: [  OK  ]
 
     def stop(self):
-        subprocess.run(["/opt/jedox/ps/jedox-suite.sh","stop"], shell=False, check=True)
+        subprocess.check_call(["/opt/jedox/ps/jedox-suite.sh","stop"], shell=False)
         #Unmounting /opt/jedox/ps/sys...done.
 
     def sign_eula(self):


### PR DESCRIPTION
Use subprocess.check_call instead of subprocess.run for older python versions. 
Tested with python 2.7.10 wich has no supprot for subprocess.run:

```
>>> from subprocess import run
  Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  ImportError: cannot import name run
```
